### PR TITLE
Feat/service2worker

### DIFF
--- a/uploadservice-okhttp/build.gradle
+++ b/uploadservice-okhttp/build.gradle
@@ -3,31 +3,15 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-parcelize'
 apply plugin: "org.jlleitschuh.gradle.ktlint"
 
-// start - do not modify this if your project is on github
-project.ext {
-    mavDevelopers = [(github_username): (maintainer)]
-    mavSiteUrl = "https://github.com/${github_username}/${github_repository_name}"
-    mavGitUrl = mavSiteUrl + '.git'
-    bugTrackerUrl = mavSiteUrl + '/issues/'
-    mavProjectName = "android-upload-service-okhttp"
-    mavLibraryLicenses = ["Apache-2.0": 'http://www.apache.org/licenses/LICENSE-2.0.txt']
-    mavLibraryDescription = "OkHttp stack implementation for Android Upload Service."
-    mavVersion = library_version
-}
-// end - do not modify this if your project is on github
-
-group = library_project_group
-version = library_version
-
 android {
     namespace "net.gotev.uploadservice.okhttp"
-    compileSdkVersion target_sdk
+    compileSdkVersion 34
 
     defaultConfig {
-        minSdkVersion min_sdk
-        targetSdkVersion target_sdk
-        versionCode version_code
-        versionName library_version
+        minSdkVersion 21
+        targetSdkVersion 34
+        versionCode 51
+        versionName '4.9.2'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles 'proguard-rules.pro'
     }
@@ -51,29 +35,27 @@ android {
 
 dependencies {
     // Testing - https://developer.android.com/training/testing/set-up-project
-    testImplementation "junit:junit:$junit_version"
+    testImplementation "junit:junit:4.13.2"
 
     // Core library
-    androidTestImplementation "androidx.test:core:$androidx_test_core_version"
+    androidTestImplementation "androidx.test:core:1.5.0"
 
     // AndroidJUnitRunner and JUnit Rules
-    androidTestImplementation "androidx.test:runner:$androidx_test_runner_version"
-    androidTestImplementation "androidx.test:rules:$androidx_test_rules_version"
+    androidTestImplementation "androidx.test:runner:1.5.2"
+    androidTestImplementation "androidx.test:rules:1.5.0"
 
     // Assertions
-    androidTestImplementation "androidx.test.ext:junit:$androidx_test_ext_junit_version"
-    androidTestImplementation "androidx.test.ext:truth:$androidx_test_ext_truth_version"
-    androidTestImplementation "com.google.truth:truth:$truth_version"
+    androidTestImplementation "androidx.test.ext:junit:1.1.5"
+    androidTestImplementation "androidx.test.ext:truth:1.5.0"
+    androidTestImplementation "com.google.truth:truth:1.0.1"
 
     // Espresso dependencies
-    androidTestImplementation "androidx.test.espresso:espresso-core:$androidx_test_espresso_version"
+    androidTestImplementation "androidx.test.espresso:espresso-core:3.5.1"
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.21"
 
     api 'com.squareup.okhttp3:okhttp:4.12.0'
     //api "net.gotev:uploadservice:${version}"
     //comment the previous line and uncomment the next line for development (it uses the local lib)
     api project(':uploadservice')
 }
-
-apply from: 'https://raw.githubusercontent.com/sky-uk/gradle-maven-plugin/master/gradle-mavenizer.gradle'

--- a/uploadservice/build.gradle
+++ b/uploadservice/build.gradle
@@ -4,36 +4,20 @@ apply plugin: 'kotlin-parcelize'
 apply plugin: "org.jlleitschuh.gradle.ktlint"
 apply plugin: 'kotlin-kapt'
 
-// start - do not modify this if your project is on github
-project.ext {
-    mavDevelopers = [(github_username): (maintainer)]
-    mavSiteUrl = "https://github.com/${github_username}/${github_repository_name}"
-    mavGitUrl = mavSiteUrl + '.git'
-    bugTrackerUrl = mavSiteUrl + '/issues/'
-    mavProjectName = "android-upload-service"
-    mavLibraryLicenses = ["Apache-2.0": 'http://www.apache.org/licenses/LICENSE-2.0.txt']
-    mavLibraryDescription = "Easily upload files in the background with automatic Android Notification Center progress indication."
-    mavVersion = library_version
-}
-// end - do not modify this if your project is on github
-
-group = library_project_group
-version = library_version
-
 android {
     namespace "net.gotev.uploadservice"
 
     defaultConfig {
-        compileSdk target_sdk
-        minSdkVersion min_sdk
-        targetSdkVersion target_sdk
-        versionCode version_code
-        versionName library_version
+        compileSdk 34
+        minSdkVersion 21
+        targetSdkVersion 34
+        versionCode 51
+        versionName '4.9.2'
 
         // https://commonsware.com/blog/2020/10/14/android-studio-4p1-library-modules-version-code.html
         // https://issuetracker.google.com/issues/158695880#comment15
-        buildConfigField 'int', 'VERSION_CODE', "$version_code"
-        buildConfigField 'String', 'VERSION_NAME', "\"$library_version\""
+        buildConfigField 'int', 'VERSION_CODE', "51"
+        buildConfigField 'String', 'VERSION_NAME', "\"4.9.2\""
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles 'proguard-rules.pro'
@@ -58,31 +42,31 @@ android {
 
 dependencies {
     // Testing - https://developer.android.com/training/testing/set-up-project
-    testImplementation "junit:junit:$junit_version"
+    testImplementation "junit:junit:4.13.2"
 
     // Core library
-    androidTestImplementation "androidx.test:core:$androidx_test_core_version"
+    androidTestImplementation "androidx.test:core:1.5.0"
 
     // AndroidJUnitRunner and JUnit Rules
-    androidTestImplementation "androidx.test:runner:$androidx_test_runner_version"
-    androidTestImplementation "androidx.test:rules:$androidx_test_rules_version"
+    androidTestImplementation "androidx.test:runner:1.5.2"
+    androidTestImplementation "androidx.test:rules:1.5.0"
 
     // Assertions
-    androidTestImplementation "androidx.test.ext:junit:$androidx_test_ext_junit_version"
-    androidTestImplementation "androidx.test.ext:truth:$androidx_test_ext_truth_version"
-    androidTestImplementation "com.google.truth:truth:$truth_version"
+    androidTestImplementation "androidx.test.ext:junit:1.1.5"
+    androidTestImplementation "androidx.test.ext:truth:1.5.0"
+    androidTestImplementation "com.google.truth:truth:1.0.1"
 
     // Espresso dependencies
-    androidTestImplementation "androidx.test.espresso:espresso-core:$androidx_test_espresso_version"
+    androidTestImplementation "androidx.test.espresso:espresso-core:3.5.1"
 
-    androidTestImplementation "com.squareup.okhttp3:mockwebserver:$mock_web_server_version"
-    androidTestImplementation "com.squareup.okhttp3:okhttp-tls:$mock_web_server_version"
+    androidTestImplementation "com.squareup.okhttp3:mockwebserver:4.9.0"
+    androidTestImplementation "com.squareup.okhttp3:okhttp-tls:4.9.0"
 
     // Support
-    implementation "androidx.appcompat:appcompat:$androidx_appcompat_version"
-    kapt "androidx.lifecycle:lifecycle-compiler:$androidx_lifecycle_version"
+    implementation "androidx.appcompat:appcompat:1.6.1"
+    kapt "androidx.lifecycle:lifecycle-compiler:2.6.1"
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.21"
+
+    implementation "androidx.work:work-runtime:2.9.0"
 }
-
-apply from: 'https://raw.githubusercontent.com/sky-uk/gradle-maven-plugin/master/gradle-mavenizer.gradle'

--- a/uploadservice/src/androidTest/java/net/gotev/uploadservice/testcore/UploadServiceTestSuite.kt
+++ b/uploadservice/src/androidTest/java/net/gotev/uploadservice/testcore/UploadServiceTestSuite.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import androidx.test.platform.app.InstrumentationRegistry
 import net.gotev.uploadservice.UploadService
 import net.gotev.uploadservice.UploadServiceConfig
+import net.gotev.uploadservice.UploadWorker
 import org.junit.After
 import org.junit.Before
 
@@ -25,5 +26,6 @@ open class UploadServiceTestSuite {
         mockWebServer.shutdown()
         appContext.deleteTestNotificationChannel()
         UploadService.stop(appContext, true)
+        UploadWorker.stop(appContext, true)
     }
 }

--- a/uploadservice/src/main/java/net/gotev/uploadservice/UploadRequest.kt
+++ b/uploadservice/src/main/java/net/gotev/uploadservice/UploadRequest.kt
@@ -70,7 +70,7 @@ constructor(protected val context: Context, protected var serverUrl: String) : P
                 "cannot call it multiple times. Check your code."
         }
 
-        check(!UploadService.taskList.contains(uploadTaskParameters.id)) {
+        check(!UploadWorker.taskList.contains(uploadTaskParameters.id)) {
             "You have tried to perform startUpload() using the same uploadID of an " +
                 "already running task. You're trying to use the same ID for multiple uploads."
         }

--- a/uploadservice/src/main/java/net/gotev/uploadservice/UploadService.kt
+++ b/uploadservice/src/main/java/net/gotev/uploadservice/UploadService.kt
@@ -98,8 +98,8 @@ class UploadService : Service() {
     private val taskObservers by lazy {
         arrayOf(
             BroadcastEmitter(this),
-            UploadServiceConfig.notificationHandlerFactory(this),
-            TaskCompletionNotifier(this)
+            UploadServiceConfig.notificationHandlerFactoryService(this),
+            TaskCompletionNotifier(service = this)
         )
     }
 

--- a/uploadservice/src/main/java/net/gotev/uploadservice/UploadServiceConfig.kt
+++ b/uploadservice/src/main/java/net/gotev/uploadservice/UploadServiceConfig.kt
@@ -107,7 +107,7 @@ object UploadServiceConfig {
      * running uploads
      */
     @JvmStatic
-    var notificationActionsObserverFactory: (UploadService) -> NotificationActionsObserver = {
+    var notificationActionsObserverFactory: (Context) -> NotificationActionsObserver = {
         NotificationActionsObserver(it)
     }
 
@@ -116,8 +116,13 @@ object UploadServiceConfig {
      * The default notification handler creates a notification for each upload task.
      */
     @JvmStatic
-    var notificationHandlerFactory: (UploadService) -> UploadTaskObserver = { uploadService ->
-        NotificationHandler(uploadService)
+    var notificationHandlerFactoryService: (UploadService) -> UploadTaskObserver = { uploadService ->
+        NotificationHandler(service = uploadService)
+    }
+
+    @JvmStatic
+    var notificationHandlerFactoryWorker: (UploadWorker) -> UploadTaskObserver = { uploadWorker ->
+        NotificationHandler(worker = uploadWorker)
     }
 
     /**

--- a/uploadservice/src/main/java/net/gotev/uploadservice/UploadTask.kt
+++ b/uploadservice/src/main/java/net/gotev/uploadservice/UploadTask.kt
@@ -11,7 +11,9 @@ import net.gotev.uploadservice.logger.UploadServiceLogger
 import net.gotev.uploadservice.network.HttpStack
 import net.gotev.uploadservice.network.ServerResponse
 import net.gotev.uploadservice.observer.task.UploadTaskObserver
+import java.io.FileNotFoundException
 import java.io.IOException
+import java.net.UnknownHostException
 import java.util.ArrayList
 import java.util.Date
 
@@ -150,16 +152,17 @@ abstract class UploadTask : Runnable {
                 } else if (attempts >= params.maxRetries) {
                     onError(exc)
                 } else {
-                    UploadServiceLogger.error(TAG, params.id, exc) { "error on attempt ${attempts + 1}. Waiting ${errorDelay}s before next attempt." }
+                    if (exc is FileNotFoundException) {
+                        UploadServiceLogger.error(TAG, params.id, exc) { "error on attempt ${attempts + 1}. Since the file was already deleted, we won't retry." }
+                        break
+                    } else if (exc is UnknownHostException) {
+                        UploadServiceLogger.error(TAG, params.id, exc) { "error. Since the host can't be reached, we won't count this retry." }
+                        attempts--
+                        sleepBeforeRetry()
+                    } else {
+                        UploadServiceLogger.error(TAG, params.id, exc) { "error on attempt ${attempts + 1}. Waiting ${errorDelay}s before next attempt." }
 
-                    val sleepDeadline = System.currentTimeMillis() + errorDelay * 1000
-
-                    sleepWhile { shouldContinue && System.currentTimeMillis() < sleepDeadline }
-
-                    errorDelay *= UploadServiceConfig.retryPolicy.multiplier.toLong()
-
-                    if (errorDelay > UploadServiceConfig.retryPolicy.maxWaitTimeSeconds) {
-                        errorDelay = UploadServiceConfig.retryPolicy.maxWaitTimeSeconds.toLong()
+                        sleepBeforeRetry()
                     }
                 }
             }
@@ -169,6 +172,18 @@ abstract class UploadTask : Runnable {
 
         if (!shouldContinue) {
             onUserCancelledUpload()
+        }
+    }
+
+    private fun sleepBeforeRetry() {
+        val sleepDeadline = System.currentTimeMillis() + errorDelay * 1000
+
+        sleepWhile { shouldContinue && System.currentTimeMillis() < sleepDeadline }
+
+        errorDelay *= UploadServiceConfig.retryPolicy.multiplier.toLong()
+
+        if (errorDelay > UploadServiceConfig.retryPolicy.maxWaitTimeSeconds) {
+            errorDelay = UploadServiceConfig.retryPolicy.maxWaitTimeSeconds.toLong()
         }
     }
 

--- a/uploadservice/src/main/java/net/gotev/uploadservice/UploadWorker.kt
+++ b/uploadservice/src/main/java/net/gotev/uploadservice/UploadWorker.kt
@@ -1,0 +1,211 @@
+package net.gotev.uploadservice
+
+import android.Manifest
+import android.app.Notification
+import android.content.Context
+import android.content.pm.PackageManager
+import androidx.core.app.ActivityCompat
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.work.Worker
+import androidx.work.WorkerParameters
+import net.gotev.uploadservice.data.UploadNotificationConfig
+import net.gotev.uploadservice.data.UploadTaskParameters
+import net.gotev.uploadservice.extensions.UploadTaskCreationParameters
+import net.gotev.uploadservice.extensions.getUploadTask
+import net.gotev.uploadservice.logger.UploadServiceLogger
+import net.gotev.uploadservice.observer.task.BroadcastEmitter
+import net.gotev.uploadservice.observer.task.TaskCompletionNotifier
+import net.gotev.uploadservice.persistence.PersistableData
+import java.util.concurrent.ConcurrentHashMap
+
+class UploadWorker(context: Context, params: WorkerParameters) : Worker(context, params) {
+
+    companion object {
+        internal val TAG = UploadWorker::class.java.simpleName
+
+        private const val UPLOAD_NOTIFICATION_BASE_ID = 1234 // Something unique
+
+        const val TASK_CREATION_PARAMS_KEY = "task-creation-params-key"
+
+        private var notificationIncrementalId = 0
+        private val uploadTasksMap = ConcurrentHashMap<String, UploadTask>()
+
+        @Volatile
+        private var foregroundUploadId: String? = null
+
+        /**
+         * Stops the upload task with the given uploadId.
+         * @param uploadId The unique upload id
+         */
+        @Synchronized
+        @JvmStatic
+        fun stopUpload(uploadId: String) {
+            uploadTasksMap[uploadId]?.cancel()
+        }
+
+        /**
+         * Gets the list of the currently active upload tasks.
+         * @return list of uploadIDs or an empty list if no tasks are currently running
+         */
+        @JvmStatic
+        val taskList: List<String>
+            @Synchronized get() = if (uploadTasksMap.isEmpty()) {
+                emptyList()
+            } else {
+                uploadTasksMap.keys().toList()
+            }
+
+        /**
+         * Stop all the active uploads.
+         */
+        @Synchronized
+        @JvmStatic
+        fun stopAllUploads() {
+            val iterator = uploadTasksMap.keys.iterator()
+
+            while (iterator.hasNext()) {
+                uploadTasksMap[iterator.next()]?.cancel()
+            }
+        }
+
+        /**
+         * Stops the service.
+         * @param context application context
+         * @param forceStop if true stops the service no matter if some tasks are running, else
+         * stops only if there aren't any active tasks
+         * @return true if the service is getting stopped, false otherwise
+         */
+        @Synchronized
+        @JvmOverloads
+        @JvmStatic
+        fun stop(context: Context, forceStop: Boolean = false) =  stopAllUploads()
+    }
+
+    var notificationConfig: (context: Context, uploadId: String) -> UploadNotificationConfig =
+        UploadServiceConfig.notificationConfigFactory
+
+    private val taskObservers by lazy {
+        arrayOf(
+            BroadcastEmitter(context),
+            UploadServiceConfig.notificationHandlerFactoryWorker(this),
+            TaskCompletionNotifier(worker = this)
+        )
+    }
+
+    private val notificationActionsObserver by lazy {
+        UploadServiceConfig.notificationActionsObserverFactory(context)
+    }
+
+    @Synchronized
+    fun holdForegroundNotification(uploadId: String, notification: Notification): Boolean {
+        if (foregroundUploadId == null) {
+            foregroundUploadId = uploadId
+        }
+
+        if (uploadId == foregroundUploadId) {
+            showNotification(UPLOAD_NOTIFICATION_BASE_ID, notification)
+            return true
+        }
+
+        return false
+    }
+
+    @Synchronized
+    fun taskCompleted(uploadId: String) {
+        removeNotification(UPLOAD_NOTIFICATION_BASE_ID)
+        val task = uploadTasksMap.remove(uploadId)
+
+        // un-hold foreground upload ID if it's been hold
+        if (UploadServiceConfig.isForegroundService && task != null && task.params.id == foregroundUploadId) {
+            UploadServiceLogger.debug(TAG, uploadId) { "now un-holded foreground notification" }
+            foregroundUploadId = null
+        }
+
+        if (UploadServiceConfig.isForegroundService && uploadTasksMap.isEmpty()) {
+            UploadServiceLogger.debug(TAG, UploadServiceLogger.NA) { "All tasks completed, stopping foreground execution" }
+        }
+    }
+
+    override fun doWork(): Result {
+        setup()
+        val success = performWork()
+        return if (success) {
+            Result.success()
+        } else {
+            Result.failure()
+        }
+    }
+
+    private fun setup() {
+        notificationActionsObserver.register()
+    }
+
+    private fun performWork(): Boolean {
+        UploadServiceLogger.debug(TAG, UploadServiceLogger.NA) {
+            "Starting UploadWorker. Debug info: $UploadServiceConfig"
+        }
+
+        val builder = NotificationCompat.Builder(applicationContext, UploadServiceConfig.defaultNotificationChannel!!)
+            .setSmallIcon(android.R.drawable.ic_menu_upload)
+            .setOngoing(true)
+            .setGroup(UploadServiceConfig.namespace)
+
+        val notification = builder.build()
+        showNotification(UPLOAD_NOTIFICATION_BASE_ID, notification)
+
+        val taskCreationParameters = getUploadTaskCreationParameters() ?: return false
+
+        if (uploadTasksMap.containsKey(taskCreationParameters.params.id)) {
+            UploadServiceLogger.error(TAG, taskCreationParameters.params.id) {
+                "Preventing upload! An upload with the same ID is already in progress. " +
+                        "Every upload must have unique ID. Please check your code and fix it!"
+            }
+            return false
+        }
+
+        // increment by 2 because the notificationIncrementalId + 1 is used internally
+        // in each UploadTask. Check its sources for more info about this.
+        notificationIncrementalId += 2
+
+        val currentTask = applicationContext.getUploadTask(
+            creationParameters = taskCreationParameters,
+            notificationId = UPLOAD_NOTIFICATION_BASE_ID + notificationIncrementalId,
+            observers = taskObservers
+        ) ?: return false
+
+        uploadTasksMap[currentTask.params.id] = currentTask
+        UploadServiceConfig.threadPool.execute(currentTask)
+
+        return true
+    }
+
+    private fun getUploadTaskCreationParameters(): UploadTaskCreationParameters? {
+        val taskCreationParamsString = inputData.getString(TASK_CREATION_PARAMS_KEY)
+        var taskParams: UploadTaskParameters? = null
+        taskCreationParamsString?.let {
+            taskParams = UploadTaskParameters.createFromPersistableData(PersistableData.fromJson(it))
+        }
+        taskParams?.let {params ->
+            return UploadTaskCreationParameters(
+                params = params,
+                notificationConfig = notificationConfig(applicationContext, params.id)
+            )
+        }
+        return null
+    }
+
+    private fun showNotification(notificationId: Int,notification: Notification) {
+        val notificationManager = NotificationManagerCompat.from(applicationContext)
+
+        if (ActivityCompat.checkSelfPermission(applicationContext, Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED) {
+            notificationManager.notify(notificationId, notification)
+        }
+    }
+
+    private fun removeNotification(notificationId: Int) {
+        val notificationManager = NotificationManagerCompat.from(applicationContext)
+        notificationManager.cancel(notificationId)
+    }
+
+}

--- a/uploadservice/src/main/java/net/gotev/uploadservice/extensions/ContextExtensions.kt
+++ b/uploadservice/src/main/java/net/gotev/uploadservice/extensions/ContextExtensions.kt
@@ -42,51 +42,6 @@ fun Context.startNewUpload(
         .setInputData(inputData).build()
     WorkManager.getInstance(this).enqueue(uploadWorkRequest)
 
-//    val intent = Intent(this, UploadService::class.java).apply {
-//        action = UploadServiceConfig.uploadAction
-//        putExtra(taskParametersKey, params)
-//        putExtra(taskNotificationConfig, notificationConfig)
-//    }
-
-//    try {
-//        /*
-//        When trying to start a service on API 26+
-//        while the app is in the background, an IllegalStateException will be fired
-//
-//        https://developer.android.com/reference/android/content/Context#startService(android.content.Intent)
-//
-//        Then why not using startForegroundService always on API 26+? Read below
-//         */
-//        startService(intent)
-//    } catch (exc: Throwable) {
-//        if (SDK_INT >= 26 && exc is IllegalStateException) {
-//            /*
-//            this is a bugged Android API and Google is not going to fix it
-//
-//            https://issuetracker.google.com/issues/76112072
-//
-//            Android SDK can not guarantee that the service is going to be started in under 5 seconds
-//            which in turn can cause the non catchable
-//
-//            RemoteServiceException: Context.startForegroundService() did not then call Service.startForeground()
-//
-//            so the library is going to use this bugged API only as a last resort, to be able
-//            to support starting uploads also when the app is in the background, but preventing
-//            non catchable exceptions when you launch uploads while the app is in foreground.
-//             */
-//            startForegroundService(intent)
-//        } else {
-//            UploadServiceLogger.error(
-//                component = "UploadService",
-//                uploadId = params.id,
-//                exception = exc,
-//                message = {
-//                    "Error while starting AndroidUploadService"
-//                }
-//            )
-//        }
-//    }
-
     return params.id
 }
 

--- a/uploadservice/src/main/java/net/gotev/uploadservice/logger/DefaultLoggerDelegate.kt
+++ b/uploadservice/src/main/java/net/gotev/uploadservice/logger/DefaultLoggerDelegate.kt
@@ -5,7 +5,7 @@ import android.util.Log
 class DefaultLoggerDelegate : UploadServiceLogger.Delegate {
 
     companion object {
-        private const val TAG = "UploadService"
+        private const val TAG = "UploadWorker"
     }
 
     override fun error(component: String, uploadId: String, message: String, exception: Throwable?) {

--- a/uploadservice/src/main/java/net/gotev/uploadservice/observer/request/NotificationActionsObserver.kt
+++ b/uploadservice/src/main/java/net/gotev/uploadservice/observer/request/NotificationActionsObserver.kt
@@ -6,6 +6,7 @@ import android.content.Intent
 import net.gotev.uploadservice.UploadService
 import net.gotev.uploadservice.UploadServiceConfig.broadcastNotificationAction
 import net.gotev.uploadservice.UploadServiceConfig.broadcastNotificationActionIntentFilter
+import net.gotev.uploadservice.UploadWorker
 import net.gotev.uploadservice.extensions.registerReceiverCompat
 import net.gotev.uploadservice.extensions.uploadIdToCancel
 import net.gotev.uploadservice.logger.UploadServiceLogger
@@ -25,6 +26,7 @@ open class NotificationActionsObserver(
                 "requested upload cancellation"
             }
             UploadService.stopUpload(it)
+            UploadWorker.stopUpload(it)
         }
     }
 

--- a/uploadservice/src/main/java/net/gotev/uploadservice/observer/request/RequestObserver.kt
+++ b/uploadservice/src/main/java/net/gotev/uploadservice/observer/request/RequestObserver.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.OnLifecycleEvent
 import net.gotev.uploadservice.UploadRequest
 import net.gotev.uploadservice.UploadService
+import net.gotev.uploadservice.UploadWorker
 import net.gotev.uploadservice.data.UploadInfo
 
 class RequestObserver @JvmOverloads constructor(
@@ -30,7 +31,7 @@ class RequestObserver @JvmOverloads constructor(
         super.register()
 
         subscribedUploadID?.let {
-            if (!UploadService.taskList.contains(it)) {
+            if (!UploadWorker.taskList.contains(it)) {
                 delegate.onCompletedWhileNotObserving()
             }
         }

--- a/uploadservice/src/main/java/net/gotev/uploadservice/observer/task/TaskCompletionNotifier.kt
+++ b/uploadservice/src/main/java/net/gotev/uploadservice/observer/task/TaskCompletionNotifier.kt
@@ -1,11 +1,12 @@
 package net.gotev.uploadservice.observer.task
 
 import net.gotev.uploadservice.UploadService
+import net.gotev.uploadservice.UploadWorker
 import net.gotev.uploadservice.data.UploadInfo
 import net.gotev.uploadservice.data.UploadNotificationConfig
 import net.gotev.uploadservice.network.ServerResponse
 
-class TaskCompletionNotifier(private val service: UploadService) : UploadTaskObserver {
+class TaskCompletionNotifier(private val service: UploadService? = null, private val worker: UploadWorker? = null) : UploadTaskObserver {
     override fun onStart(
         info: UploadInfo,
         notificationId: Int,
@@ -41,6 +42,7 @@ class TaskCompletionNotifier(private val service: UploadService) : UploadTaskObs
         notificationId: Int,
         notificationConfig: UploadNotificationConfig
     ) {
-        service.taskCompleted(info.uploadId)
+        service?.taskCompleted(info.uploadId)
+        worker?.taskCompleted(info.uploadId)
     }
 }


### PR DESCRIPTION
- creating an UploadWorker based on existing UploadService
- reusing parts of existing codebase that are needed for the Worker to function with WorkManager and handle the upload
- custom error handling for two use-cases: file already deleted, unknown host
- keeping old UploadService for reference
- some config cleanup since we won't be pushing this to Maven and to be able to build locally